### PR TITLE
Fix error when calling method with no arguments.

### DIFF
--- a/src/dfp.ts
+++ b/src/dfp.ts
@@ -37,7 +37,7 @@ export class DFP {
             get: function get(target, propertyKey) {
                 const method = propertyKey.toString();
                 if (target.hasOwnProperty(method) && !['setToken'].includes(method)) {
-                    return async function run(dto: any) {
+                    return async function run(dto: any = {}) {
                         const res = await promiseFromCallback((cb) => client[method](dto, cb));
                         return DFP.parse(res);
                     };


### PR DESCRIPTION
The soap library apparently can't serialize soap requests for methods that
take no arguments. This is a simple fix which sets the default value to the
empty object `{}`.

Fixes #13.