### PR TITLE
Bump soap 0.36 -> 0.40

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "soap": "0.36.0"
+    "soap": "0.40.0"
   },
   "files": [
     "README.md",


### PR DESCRIPTION
The current soap version uses an old version of npm which has a security issues.
https://github.com/advisories/GHSA-p8p7-x288-28g6


Currently there is an issue with lower versions of Soap, bump it a few versions without having to deal with a major change to fix it.